### PR TITLE
Fix social buttons style

### DIFF
--- a/style.css
+++ b/style.css
@@ -1125,20 +1125,6 @@ pre.code {
   line-height: 1.65;
 }
 
-.hatena-bookmark-button-frame {
-  width: 124px !important;
-}
-
-.facebook-like-button {
-  margin-right: 6px;
-  width: 100px !important;
-  height: 20px !important;
-}
-
-.twitter-share-button {
-  width: 93px !important;
-}
-
 .page-archive .archive-entries .social-buttons {
   display: none;
 }


### PR DESCRIPTION
はてなブログ側のデザイン変更に伴い、スタイルを修正（というか幅や高さに関するスタイルを削除）。
- [PCでも、デフォルトのソーシャルボタンを大きく表示するようにしました - はてなブログ開発ブログ](http://staff.hatenablog.com/entry/2014/11/13/184000)
